### PR TITLE
Allow null credit card type

### DIFF
--- a/yaml/schemas/Account.yaml
+++ b/yaml/schemas/Account.yaml
@@ -82,6 +82,7 @@ Account:
           format: string
           example: "monthlyFull"
           enum:
+            - ""
             - "monthlyFull"
         monthly_payment_date:
           type: string

--- a/yaml/schemas/Account.yaml
+++ b/yaml/schemas/Account.yaml
@@ -87,6 +87,7 @@ Account:
         monthly_payment_date:
           type: string
           format: date
+          nullable: true
           example: "2017-01-01"
         account_number:
           type: string


### PR DESCRIPTION
Field is optional, so empty string should be allowed too

Probably same issue is elsewhere, just didn't hit it yet