### PR TITLE
Consistency for operationId

### DIFF
--- a/yaml/paths/accounts.yaml
+++ b/yaml/paths/accounts.yaml
@@ -5,7 +5,7 @@
     summary: List all accounts.
     description: |
       This endpoint returns a list of all the accounts owned by the authenticated user.
-    operationId: getAccounts
+    operationId: listAccount
     parameters:
     - in: query
       name: page
@@ -189,7 +189,7 @@
     summary: List all piggy banks related to the account.
     description: |
       This endpoint returns a list of all the piggy banks connected to the account.
-    operationId: getPiggiesByAccount
+    operationId: listPiggyBankByAccount
     parameters:
     - in: path
       name: id
@@ -218,7 +218,7 @@
     summary: List all transactions related to the account.
     description: |
       This endpoint returns a list of all the transactions connected to the account.
-    operationId: getTransactionsByAccount
+    operationId: listTransactionByAccount
     parameters:
     - in: path
       name: id

--- a/yaml/paths/attachments.yaml
+++ b/yaml/paths/attachments.yaml
@@ -3,7 +3,7 @@
     summary: List all attachments.
     description: |
       This endpoint lists all attachments.
-    operationId: getAttachments
+    operationId: listAttachment
     tags:
       - attachments
     parameters:

--- a/yaml/paths/available_budgets.yaml
+++ b/yaml/paths/available_budgets.yaml
@@ -3,7 +3,7 @@
     summary: List all available budget amounts.
     description: |
       Firefly III allows users to set the amount that is available to be budgeted in so-called "available budgets". For example, the user could have 1200,- available to be divided during the coming month. This amount is used on the /budgets page. This endpoint returns all of these amounts and the periods for which they are set.
-    operationId: getAvailableBudgets
+    operationId: listAvailableBudget
     tags:
       - available_budgets
     parameters:

--- a/yaml/paths/bills.yaml
+++ b/yaml/paths/bills.yaml
@@ -2,7 +2,7 @@
   get:
     summary: List all bills.
     description: This endpoint will list all the user's bills.
-    operationId: getBills
+    operationId: listBill
     tags:
       - bills
     parameters:
@@ -169,7 +169,7 @@
   get:
     summary: List all attachments uploaded to the bill.
     description: This endpoint will list all attachments linked to the bill.
-    operationId: getAttachmentsByBill
+    operationId: listAttachmentByBill
     tags:
       - bills
     parameters:
@@ -198,7 +198,7 @@
   get:
     summary: List all rules associated with the bill.
     description: This endpoint will list all rules that have an action to set the bill to this bill.
-    operationId: getRulesByBill
+    operationId: listRuleByBill
     tags:
       - bills
     parameters:
@@ -220,7 +220,7 @@
   get:
     summary: List all transactions associated with the  bill.
     description: This endpoint will list all transactions linked to this bill.
-    operationId: getTransactionsByBill
+    operationId: listTransactionByBill
     tags:
       - bills
     parameters:

--- a/yaml/paths/budgets.yaml
+++ b/yaml/paths/budgets.yaml
@@ -2,7 +2,7 @@
   get:
     summary: List all budgets.
     description: List all the budgets the user has made. If the start date and end date are submitted as well, the "spent" array will be updated accordingly.
-    operationId: getBudgets
+    operationId: listBudget
     tags:
       - budgets
     parameters:
@@ -172,7 +172,7 @@
   get:
     summary: All transactions to a budget.
     description: Get all transactions linked to a budget, possibly limited by start and end
-    operationId: getTransactionsByBudget
+    operationId: listTransactionByBudget
     tags:
       - budgets
     parameters:
@@ -246,7 +246,7 @@
               $ref: '#/components/schemas/TransactionArray'
 /api/v1/budgets/{id}/limits:
   get:
-    operationId: getBudgetLimits
+    operationId: listBudgetLimit
     description: |
         Get all budget limits for this budget and the money spent, and money left. You can limit the list by submitting a date range as well. The "spent" array for each budget limit is NOT influenced by the start and end date of your query, but by the start and end date of the budget limit itself.
     summary: Get all limits
@@ -410,7 +410,7 @@
   get:
     summary: List all transactions by a budget limit ID.
     description: List all the transactions within one budget limit. The start and end date are dictated by the budget limit.
-    operationId: getTransactionsByBudgetLimit
+    operationId: listTransactionByBudgetLimit
     tags:
       - budgets
     parameters:

--- a/yaml/paths/categories.yaml
+++ b/yaml/paths/categories.yaml
@@ -2,7 +2,7 @@
   get:
     summary: List all categories.
     description: List all categories.
-    operationId: getCategories
+    operationId: listCategory
     tags:
       - categories
     parameters:
@@ -133,7 +133,7 @@
   get:
     summary: List all transactions in a category.
     description: List all transactions in a category, optionally limited to the date ranges specified.
-    operationId: getTransactionsByCategory
+    operationId: listTransactionByCategory
     tags:
       - categories
     parameters:

--- a/yaml/paths/currencies.yaml
+++ b/yaml/paths/currencies.yaml
@@ -2,7 +2,7 @@
   get:
     summary: List all currencies.
     description: List all currencies.
-    operationId: getCurrencies
+    operationId: listCurrency
     tags:
       - currencies
     parameters:
@@ -206,7 +206,7 @@
   get:
     summary: List all accounts with this currency.
     description: List all accounts with this currency.
-    operationId: getAccountsByCurrency
+    operationId: listAccountByCurrency
     tags:
       - currencies
     parameters:
@@ -276,7 +276,7 @@
   get:
     summary: List all available budgets with this currency.
     description: List all available budgets with this currency.
-    operationId: getAvailableBudgetsByCurrency
+    operationId: listAvailableBudgetByCurrency
     tags:
       - currencies
     parameters:
@@ -306,7 +306,7 @@
   get:
     summary: List all bills with this currency.
     description: List all bills with this currency.
-    operationId: getBillsByCurrency
+    operationId: listBillByCurrency
     tags:
       - currencies
     parameters:
@@ -336,7 +336,7 @@
   get:
     summary: List all budget limits with this currency
     description: List all budget limits with this currency
-    operationId: getBudgetLimitsByCurrency
+    operationId: listBudgetLimitByCurrency
     tags:
       - currencies
     parameters:
@@ -382,7 +382,7 @@
   get:
     summary: List all known exchange rates with (from or to) this currency.
     description: List all known exchange rates.
-    operationId: getExchangeRatesByCurrency
+    operationId: listExchangeRateByCurrency
     tags:
       - currencies
     parameters:
@@ -436,7 +436,7 @@
   get:
     summary: List all recurring transactions with this currency.
     description: List all recurring transactions with this currency.
-    operationId: getRecurrencesByCurrency
+    operationId: listRecurrenceByCurrency
     tags:
       - currencies
     parameters:
@@ -466,7 +466,7 @@
   get:
     summary: List all rules with this currency.
     description: List all rules with this currency.
-    operationId: getRulesByCurrency
+    operationId: listRuleByCurrency
     tags:
       - currencies
     parameters:
@@ -496,7 +496,7 @@
   get:
     summary: List all transactions with this currency.
     description: List all transactions with this currency.
-    operationId: getTransactionsByCurrency
+    operationId: listTransactionByCurrency
     tags:
       - currencies
     parameters:

--- a/yaml/paths/import.yaml
+++ b/yaml/paths/import.yaml
@@ -3,7 +3,7 @@
     description: List all imports
     tags:
       - import
-    operationId: getImports
+    operationId: listImport
     parameters:
     - in: query
       name: page
@@ -52,7 +52,7 @@
     summary: List all transactions related to the import job. The correlation is made through the tag.
     description: |
       See summary
-    operationId: getTransactionsByImport
+    operationId: listTransactionByImport
     parameters:
     - in: path
       name: key

--- a/yaml/paths/links.yaml
+++ b/yaml/paths/links.yaml
@@ -5,7 +5,7 @@
     summary: List all types of links.
     description: |
       List all the link types the system has. These include the default ones as well as any new ones.
-    operationId: getLinkTypes
+    operationId: listLinkType
     parameters:
     - in: query
       name: page
@@ -144,7 +144,7 @@
     summary: List all transactions under this link type.
     description: |
       List all transactions under this link type, both the inward and outward transactions.
-    operationId: getTransactionsByLinkType
+    operationId: listTransactionByLinkType
     parameters:
     - in: path
       name: id
@@ -214,7 +214,7 @@
     summary: List all transaction links.
     description: |
       List all the transaction links.
-    operationId: getTransactionLinks
+    operationId: listTransactionLink
     parameters:
     - in: query
       name: page

--- a/yaml/paths/piggy_banks.yaml
+++ b/yaml/paths/piggy_banks.yaml
@@ -2,7 +2,7 @@
   get:
     summary: List all piggy banks.
     description: List all piggy banks.
-    operationId: getPiggyBanks
+    operationId: listPiggyBank
     tags:
       - piggy_banks
     parameters:
@@ -133,7 +133,7 @@
   get:
     summary: List all events linked to a piggy bank.
     description: List all events linked to a piggy bank (adding and removing money).
-    operationId: getEventsByPiggyBank
+    operationId: listEventByPiggyBank
     tags:
       - piggy_banks
     parameters:

--- a/yaml/paths/preferences.yaml
+++ b/yaml/paths/preferences.yaml
@@ -2,7 +2,7 @@
   get:
     summary: List all users preferences.
     description: List all preferences of the user.
-    operationId: getPreferences
+    operationId: listPreference
     tags:
       - preferences
     parameters:

--- a/yaml/paths/recurring.yaml
+++ b/yaml/paths/recurring.yaml
@@ -133,7 +133,7 @@
   get:
     summary: List all transactions created by a recurring transaction.
     description: List all transactions created by a recurring transaction, optionally limited to the date ranges specified.
-    operationId: getTransactionsByRecurrence
+    operationId: listTransactionByRecurrence
     tags:
       - recurrences
     parameters:

--- a/yaml/paths/rule_groups.yaml
+++ b/yaml/paths/rule_groups.yaml
@@ -2,7 +2,7 @@
   get:
     summary: List all rule groups.
     description: List all rule groups.
-    operationId: getRuleGroups
+    operationId: listRuleGroup
     tags:
       - rule_groups
     parameters:
@@ -204,7 +204,7 @@
   get:
     summary: List rules in this rule group.
     description: List rules in this rule group.
-    operationId: getRulesByGroup
+    operationId: listRuleByGroup
     tags:
       - rule_groups
     parameters:

--- a/yaml/paths/rules.yaml
+++ b/yaml/paths/rules.yaml
@@ -2,7 +2,7 @@
   get:
     summary: List all rules.
     description: List all rules.
-    operationId: getRules
+    operationId: listRule
     tags:
       - rules
     parameters:

--- a/yaml/paths/tags.yaml
+++ b/yaml/paths/tags.yaml
@@ -33,7 +33,7 @@
   get:
     summary: List all tags.
     description: List all of the user's tags.
-    operationId: getTags
+    operationId: listTag
     tags:
       - tags
     parameters:
@@ -173,7 +173,7 @@
   get:
     summary: "List all transactions with this tag."
     description: "List all transactions with this tag."
-    operationId: getTransactionsByTag
+    operationId: listTransactionByTag
     tags:
       - tags
     parameters:

--- a/yaml/paths/transactions.yaml
+++ b/yaml/paths/transactions.yaml
@@ -3,7 +3,7 @@
     summary: |
       List all the user's transactions.
     description: List all the user's transactions.
-    operationId: getTransactions
+    operationId: listTransaction
     tags:
       - transactions
     parameters:
@@ -174,7 +174,7 @@
   get:
     summary: Lists all attachments.
     description: Lists all attachments.
-    operationId: getAttachmentsByTransactions
+    operationId: listAttachmentByTransaction
     tags:
       - transactions
     parameters:
@@ -205,7 +205,7 @@
   get:
     summary: Lists all piggy bank events.
     description: Lists all piggy bank events.
-    operationId: getEventsByTransactions
+    operationId: listEventByTransaction
     tags:
       - transactions
     parameters:

--- a/yaml/paths/users.yaml
+++ b/yaml/paths/users.yaml
@@ -2,7 +2,7 @@
   get:
     summary: List all users.
     description: List all the users in this instance of Firefly III.
-    operationId: getUsers
+    operationId: listUser
     tags:
       - users
     parameters:


### PR DESCRIPTION
I encourage discussion on this one.

Basically what I did was:

1. Put every model name (Account, Currency...) in singular
2. Convert `getModelss` to `listModel` so no duplicate due to 1.
3. Open every shortcut (`getPiggiesByAccount` → `listPiggyBankByAccount`)

This will enable listing every action possible with a model, and figure out in a deterministic way what those actions are. This enable for greater re-usability in the client application. We can also do that with other things, but there are some limitations:

- API paths: they are hard to parse and sometimes not consistent, e.g. `/api/v1/attachments` and `/api/v1/attachment/{id}` (should I fill an issue for this btw?)
- tags: They're better off grouping requests by category in Swagger UI, and they don't provide enough informations by themselves unless you start to add a lot of them.

Also, this will add consistency with the schemas (e.g. what's the schema for `getAccount` ? You can either read `path['responses']['200']['content']['application/json']['schema']['data']` or just extract the `get` out of the `operationId` with this PR).

**However**, there is still be a consistency gap between the `type` field returned by the API, but to be consistent all the way with the [JSON:API spec](https://jsonapi.org/format/#document-top-level) we'd need to change the `operationId` fields and the schema names in the spec to `camel_case` and plural rather than `PascalCase` and singular. AFAIK there's nothing preventing that in the OpenAPI specification, it's only unusual. Does that sound good to you? If so, I would gladly do the renaming work (not that's a lot to do when you know how to use `sed` :smile: ).