### PR TITLE
Added `trigger` to Rule

### DIFF
--- a/yaml/schemas/Rule.yaml
+++ b/yaml/schemas/Rule.yaml
@@ -42,6 +42,14 @@ Rule:
           type: boolean
           format: boolean
           example: true
+        trigger:
+          type: string
+          format: string
+          example: store-journal
+          description: Which action is necessary for the rule to fire? Use either store-journal or update-journal.
+          enum:
+          - "store-journal"
+          - "update-journal"
         strict:
           type: boolean
           format: boolean


### PR DESCRIPTION
Due to fix for https://github.com/firefly-iii/firefly-iii/issues/2477

I will probably add the "does not have to be filled entierly" to all the objects that supports that at once later, when I will have tested it.