### PR TITLE
Fix documentation for type of Account::interest returned

### DIFF
--- a/yaml/schemas/Account.yaml
+++ b/yaml/schemas/Account.yaml
@@ -143,9 +143,9 @@ Account:
       example: "2017-09-17"
       description: "Mandatory when type is liability. Start date for the liability."
     interest:
-      type: number
-      format: float
-      example: 3
+      type: string
+      format: string
+      example: "5.3"
       description: "Mandatory when type is liability. Interest percentage."
     interest_period:
       type: string


### PR DESCRIPTION
I did a request here: https://api-docs.firefly-iii.org/#/accounts/getAccount, for account 41.

And this is the value that I got:

```
{
  "data": {
    "type": "accounts",
    "id": "41",
    "attributes": {
      "created_at": "2020-02-11T15:00:31+01:00",
      "updated_at": "2020-02-11T15:00:31+01:00",
      "active": true,
      "name": "AMEX Credit Card debt",
      "type": "liabilities",
      "account_role": null,
      "currency_id": 1,
      "currency_code": "EUR",
      "currency_symbol": "€",
      "currency_decimal_places": 2,
      "current_balance": 0,
      "current_balance_date": "2020-02-11",
      "notes": null,
      "monthly_payment_date": null,
      "credit_card_type": null,
      "account_number": null,
      "iban": null,
      "bic": null,
      "virtual_balance": 0,
      "opening_balance": null,
      "opening_balance_date": null,
      "liability_type": "debt",
      "liability_amount": null,
      "liability_start_date": null,
      "interest": "5.3",
      "interest_period": "yearly",
      "include_net_worth": true,
      "longitude": null,
      "latitude": null,
      "zoom_level": null
    },
    "links": {
      "0": {
        "rel": "self",
        "uri": "/accounts/41"
      },
      "self": "https://demo.firefly-iii.org/api/v1/accounts/41"
    }
  }
}
```