### PR TITLE
Fix invalid path parameter name

### DIFF
--- a/yaml/paths/tags.yaml
+++ b/yaml/paths/tags.yaml
@@ -232,12 +232,13 @@
       - tags
     parameters:
     - in: path
-      name: id
+      name: tag
+      description: Either the tag itself or the tag ID.
       required: true
       schema:
-        type: integer
-        example: 1
-      description: The ID of the tag.
+        type: string
+        format: string
+        example: groceries
     - in: query
       name: page
       description: Page number. The default pagination is 50.


### PR DESCRIPTION
~~Previously the path parameter was tag, but it was declared as id in the parameter list. Changed to using tag_id to clearly communicate that it's the tag id.~~

EDIT: ~~All other places `id` is simply used, so switching back to simply fixing the error.~~

EDIT2: Now it rather changes the parameter description so that it matches other paths where either a tag or an id can be used.