### PR TITLE
Add missing type to TransactionSplit

### DIFF
--- a/yaml/schemas/TransactionSplit.yaml
+++ b/yaml/schemas/TransactionSplit.yaml
@@ -31,6 +31,7 @@ TransactionSplit:
         - deposit
         - transfer
         - reconciliation
+        - opening balance
     date:
       type: string
       format: date


### PR DESCRIPTION
Hi @JC5 

I believe this entry is missing from the enum. When creating an Account with an OpeningBalance, it creates a transaction, and within that Transaction, the TransactionSplit has the type "opening balance".