### PR TITLE
Account now returns strings for amounts

### DIFF
--- a/yaml/schemas/Account.yaml
+++ b/yaml/schemas/Account.yaml
@@ -46,9 +46,9 @@ Account:
       format: string
       example: "7009312345678"
     opening_balance:
-      type: number
-      format: double
-      example: -1012.12
+      type: string
+      format: amount
+      example: "-1012.12"
     opening_balance_date:
       type: string
       format: date


### PR DESCRIPTION
As per https://github.com/firefly-iii/firefly-iii/commit/c4979bdd27ccef4fb94c94f3470e570db120dc55, this should be a string right?