### PR TITLE
refactor:  oneof into wrapper $ref.

### DIFF
--- a/yaml/schemas/models/Preference/Preference.yaml
+++ b/yaml/schemas/models/Preference/Preference.yaml
@@ -19,13 +19,6 @@ Preference:
       format: string
       example: currencyPreference
     data:
-      oneOf:
-        - type: boolean
-        - type: string
-        - type: object
-        - type: array
-          items:
-            type: string
-            format: string
+      $ref: '#/components/schemas/PolymorphicProperty'
       example: "EUR"
       description: "The actual preference content."

--- a/yaml/schemas/models/Preference/PreferenceUpdate.yaml
+++ b/yaml/schemas/models/Preference/PreferenceUpdate.yaml
@@ -4,13 +4,6 @@ PreferenceUpdate:
     - data
   properties:
     data:
-      oneOf:
-        - type: boolean
-        - type: string
-        - type: object
-        - type: array
-          items:
-            type: string
-            format: string
+      $ref: '#/components/schemas/PolymorphicProperty'
       example: "EUR"
       description: "The actual preference content."

--- a/yaml/schemas/properties/PolymorphicProperty.yaml
+++ b/yaml/schemas/properties/PolymorphicProperty.yaml
@@ -1,0 +1,8 @@
+PolymorphicProperty:
+  oneOf:
+    - type: boolean
+    - type: string
+    - type: object
+    - type: array
+      items:
+        $ref: '#/components/schemas/StringArrayItem'

--- a/yaml/schemas/properties/StringArray.yaml
+++ b/yaml/schemas/properties/StringArray.yaml
@@ -1,0 +1,5 @@
+StringArray:
+  type: array
+  items:
+    $ref: '#/components/schemas/StringArrayItem'
+

--- a/yaml/schemas/properties/StringArrayItem.yaml
+++ b/yaml/schemas/properties/StringArrayItem.yaml
@@ -1,0 +1,3 @@
+StringArrayItem:
+  type: string
+  format: string

--- a/yaml/schemas/system/Configuration.yaml
+++ b/yaml/schemas/system/Configuration.yaml
@@ -10,14 +10,7 @@ Configuration:
       description: "Title of the configuration value."
       $ref: '#/components/schemas/ConfigValueFilter'
     value:
-      oneOf:
-        - type: boolean
-        - type: string
-        - type: object
-        - type: array
-          items:
-            type: string
-            format: string
+      $ref: '#/components/schemas/PolymorphicProperty'
       example: "some-variable"
       description: "Content of the configuration variable. Is very dynamic and can be anything from booleans to arrays."
     editable:

--- a/yaml/schemas/system/ConfigurationUpdate.yaml
+++ b/yaml/schemas/system/ConfigurationUpdate.yaml
@@ -4,13 +4,6 @@ ConfigurationUpdate:
     - value
   properties:
     value:
-      oneOf:
-        - type: boolean
-        - type: string
-        - type: object
-        - type: array
-          items:
-            type: string
-            format: string
+      $ref: '#/components/schemas/PolymorphicProperty'
       example: "Some-new-config var"
       description: Can be a number, a string, boolean or object. This depends on the actual configuration value.


### PR DESCRIPTION
Refactor `oneOf` fields into a wrapper class to assist in working with 3rd party OpenAPI Client tool generators.

Naming is hard, called it `PolymorphicProperty` feel free to describe it better.

### Motivation
Challenges relating to the generation of clients in various languages (Java/c#) when using `oneOf`.
One workaround presented by user @lpar is to wrap the `oneOf` into a wrapper class. See https://github.com/OpenAPITools/openapi-generator/issues/10880

This PR would assist in being able to generate a client wrapper due to outstanding issues in 3rd party tooling.

