### PR TITLE
Feat: set explicit defaults when indicated in documentation

### DIFF
--- a/yaml/schemas/models/Account/Account.yaml
+++ b/yaml/schemas/models/Account/Account.yaml
@@ -18,6 +18,7 @@ Account:
       type: boolean
       format: boolean
       example: false
+      default: true
       description: "If omitted, defaults to true."
     order:
       type: integer
@@ -102,6 +103,7 @@ Account:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: "If omitted, defaults to true."
     credit_card_type:
       $ref: '#/components/schemas/CreditCardType'

--- a/yaml/schemas/models/Account/AccountStore.yaml
+++ b/yaml/schemas/models/Account/AccountStore.yaml
@@ -54,6 +54,7 @@ AccountStore:
       type: boolean
       format: boolean
       example: false
+      default: true
       description: "If omitted, defaults to true."
     order:
       type: integer
@@ -64,6 +65,7 @@ AccountStore:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: "If omitted, defaults to true."
     account_role:
       $ref: '#/components/schemas/AccountRoleProperty'

--- a/yaml/schemas/models/Account/AccountUpdate.yaml
+++ b/yaml/schemas/models/Account/AccountUpdate.yaml
@@ -50,6 +50,7 @@ AccountUpdate:
       type: boolean
       format: boolean
       example: false
+      default: true
       description: "If omitted, defaults to true."
     order:
       type: integer
@@ -60,6 +61,7 @@ AccountUpdate:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: "If omitted, defaults to true."
     account_role:
       $ref: '#/components/schemas/AccountRoleProperty'

--- a/yaml/schemas/models/Rule/Rule.yaml
+++ b/yaml/schemas/models/Rule/Rule.yaml
@@ -46,6 +46,7 @@ Rule:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: Whether or not the rule is even active. Default is true.
     strict:
       type: boolean
@@ -56,6 +57,7 @@ Rule:
       type: boolean
       format: boolean
       example: false
+      default: false
       description: If this value is true and the rule is triggered, other rules  after this one in the group will be skipped. Default value is false.
     triggers:
       type: array

--- a/yaml/schemas/models/Rule/RuleStore.yaml
+++ b/yaml/schemas/models/Rule/RuleStore.yaml
@@ -35,11 +35,13 @@ RuleStore:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: Whether or not the rule is even active. Default is true.
     strict:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: If the rule is set to be strict, ALL triggers must hit in order for the rule to fire. Otherwise, just one is enough. Default value is true.
     stop_processing:
       type: boolean

--- a/yaml/schemas/models/Rule/RuleUpdate.yaml
+++ b/yaml/schemas/models/Rule/RuleUpdate.yaml
@@ -24,6 +24,7 @@ RuleUpdate:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: Whether or not the rule is even active. Default is true.
     strict:
       type: boolean
@@ -34,6 +35,7 @@ RuleUpdate:
       type: boolean
       format: boolean
       example: false
+      default: false
       description: If this value is true and the rule is triggered, other rules  after this one in the group will be skipped. Default value is false.
     triggers:
       type: array

--- a/yaml/schemas/models/RuleAction/RuleAction.yaml
+++ b/yaml/schemas/models/RuleAction/RuleAction.yaml
@@ -36,9 +36,11 @@ RuleAction:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: If the action is active. Defaults to true.
     stop_processing:
       type: boolean
       format: boolean
       example: false
+      default: false
       description: When true, other actions will not be fired after this action has fired. Defaults to false.

--- a/yaml/schemas/models/RuleAction/RuleActionStore.yaml
+++ b/yaml/schemas/models/RuleAction/RuleActionStore.yaml
@@ -21,9 +21,11 @@ RuleActionStore:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: If the action is active. Defaults to true.
     stop_processing:
       type: boolean
       format: boolean
       example: false
+      default: false
       description: When true, other actions will not be fired after this action has fired. Defaults to false.

--- a/yaml/schemas/models/RuleTrigger/RuleTrigger.yaml
+++ b/yaml/schemas/models/RuleTrigger/RuleTrigger.yaml
@@ -36,9 +36,11 @@ RuleTrigger:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: If the trigger is active. Defaults to true.
     stop_processing:
       type: boolean
       format: boolean
       example: false
+      default: false
       description: When true, other triggers will not be checked if this trigger was triggered. Defaults to false.

--- a/yaml/schemas/models/RuleTrigger/RuleTriggerStore.yaml
+++ b/yaml/schemas/models/RuleTrigger/RuleTriggerStore.yaml
@@ -20,9 +20,11 @@ RuleTriggerStore:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: If the trigger is active. Defaults to true.
     stop_processing:
       type: boolean
       format: boolean
       example: false
+      default: false
       description: When true, other triggers will not be checked if this trigger was triggered. Defaults to false.

--- a/yaml/schemas/models/TransactionCurrency/Currency.yaml
+++ b/yaml/schemas/models/TransactionCurrency/Currency.yaml
@@ -19,6 +19,7 @@ Currency:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: Defaults to true
     default:
       type: boolean

--- a/yaml/schemas/models/TransactionCurrency/CurrencyStore.yaml
+++ b/yaml/schemas/models/TransactionCurrency/CurrencyStore.yaml
@@ -9,6 +9,7 @@ CurrencyStore:
       type: boolean
       format: boolean
       example: true
+      default: true
       description: Defaults to true
     default:
       type: boolean


### PR DESCRIPTION
When schema documentation indicates a default enforce it in the API schema setting `default: <value>`. 
