### PR TITLE
Fix account schema for interest period

### DIFF
--- a/yaml/schemas/models/Account/Account.yaml
+++ b/yaml/schemas/models/Account/Account.yaml
@@ -125,7 +125,7 @@ Account:
       description: "Mandatory when type is liability. Interest percentage."
       nullable: true
     interest_period:
-      $ref: '#/components/schemas/LiabilityDirection'
+      $ref: '#/components/schemas/InterestPeriod'
     notes:
       type: string
       format: string


### PR DESCRIPTION
The `interest_period` sub-schema was pointing to the wrong schema (liability type as opposed to time-period)

[The published 1.5.6 schema was affected by this]