### PR TITLE
fix for v1/autocomplete/accounts type(s) parameter

### DIFF
--- a/yaml/v1/paths/autocomplete/accounts.yaml
+++ b/yaml/v1/paths/autocomplete/accounts.yaml
@@ -15,11 +15,14 @@
         example: "2020-09-17"
         description: If the account is an asset account or a liability, the autocomplete will also return the balance of the account on this date.
       - in: query
-        name: type
+        name: types
         description: Optional filter on the account type(s) used in the autocomplete.
         required: false
+        explode: false
         schema:
-          $ref: '#/components/schemas/AccountTypeFilter'
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountTypeFilter'
     summary: Returns all accounts of the user returned in a basic auto-complete array.
     responses:
       !unauthenticatedResponse,3


### PR DESCRIPTION
Looking at the HTTP requests of the web interface, for `v1/autocomplete/accounts` a `types` (with `s`) argument is sent with the list of account types that should be filtered for, separated by comma.

This PR fixes the swagger documentation to reflect that.