### PR TITLE
Fix openapi account schema dates

### DIFF
--- a/yaml/v1/schemas/models/Account/Account.yaml
+++ b/yaml/v1/schemas/models/Account/Account.yaml
@@ -61,8 +61,8 @@ Account:
       readOnly: true
     current_balance_date:
       type: string
-      format: date-time
-      example: "2018-09-17T12:46:47+01:00"
+      format: date
+      example: "2018-09-17"
       readOnly: true
     iban:
       type: string
@@ -90,10 +90,10 @@ Account:
       nullable: true
       example: "1012.12"
       description: Represents the current debt for liabilities.
-    opening_balance_date:
+    opening_balance:
       type: string
-      format: date-time
-      example: "2018-09-17T12:46:47+01:00"
+      format: date
+      example: "2018-09-17"
       nullable: true
       description: Represents the date of the opening balance.
     virtual_balance:
@@ -111,8 +111,8 @@ Account:
     monthly_payment_date:
       nullable: true
       type: string
-      format: date-time
-      example: "2018-09-17T12:46:47+01:00"
+      format: date
+      example: "2018-09-17"
       description: "Mandatory when the account_role is ccAsset. Moment at which CC payment installments are asked for by the bank."
     liability_type:
       $ref: '#/components/schemas/LiabilityType'


### PR DESCRIPTION
The current yaml schema described `date` types as `date-time`.

The [Accounts example](https://api-docs.firefly-iii.org/?urls.primaryName=2.0.0%20(v1)):

```
{
  "name": "My checking account",
  "type": "asset",
  "iban": "GB98MIDL07009312345678",
  "bic": "BOFAUS3N",
  "account_number": "7009312345678",
  "opening_balance": "-1012.12",
  "opening_balance_date": "2018-09-17",
...
}
```

This shows that `opening_balance_date` is a date, not a datetime. Still, the [openapi YAML](https://api-docs.firefly-iii.org/firefly-iii-2.0.0-v1.yaml) requires a `date-time`.

This makes [openapi generators](https://openapi-generator.tech/docs/usage/#generate) unusable as it's very hard to get around the validation.

This PR proposes to change the account YAML schema from `date-time` to `date`.