### PR TITLE
Disable currencies should accept a string

### DIFF
--- a/yaml/v1/paths/models/transaction-currency.yaml
+++ b/yaml/v1/paths/models/transaction-currency.yaml
@@ -96,7 +96,7 @@
         name: code
         required: true
         schema:
-          type: integer
+          type: string
           example: GBP
         description: The currency code.
     responses:


### PR DESCRIPTION
The enable currencies endpoint accepts the string currency code. The disable currencies endpoint requires an integer instead.

I tested the enable currencies endpoint and it works.

Note, that I tested on overwritten disable currencies endpoint as well with the `openapi-generator`, but it returns a 415 error.