### PR TITLE
Swagger yaml fixes on nullable fields

### DIFF
--- a/yaml/shared/models/PageLink.yaml
+++ b/yaml/shared/models/PageLink.yaml
@@ -13,10 +13,12 @@ PageLink:
       type: string
       format: uri
       example: "https://demo.firefly-iii.org/api/v1/OBJECT?&page=3"
+      nullable: true
     prev:
       type: string
       format: uri
       example: "https://demo.firefly-iii.org/api/v1/OBJECT?&page=2"
+      nullable: true
     last:
       type: string
       format: uri

--- a/yaml/shared/models/TransactionSplit/TransactionSplit.yaml
+++ b/yaml/shared/models/TransactionSplit/TransactionSplit.yaml
@@ -223,9 +223,9 @@ TransactionSplit:
       description: System generated identifier for original creator of transaction.
       readOnly: true
     recurrence_id:
-      type: integer
+      type: string
       nullable: true
-      format: int32
+      format: string
       description: Reference to recurrence that made the transaction.
       readOnly: true
     recurrence_total:

--- a/yaml/v1/schemas/models/Attachment/Attachment.yaml
+++ b/yaml/v1/schemas/models/Attachment/Attachment.yaml
@@ -43,6 +43,7 @@ Attachment:
       type: string
       format: string
       example: "Some PDF file"
+      nullable: true
     notes:
       type: string
       format: string

--- a/yaml/v1/schemas/models/Bill/Bill.yaml
+++ b/yaml/v1/schemas/models/Bill/Bill.yaml
@@ -58,11 +58,13 @@ Bill:
       format: date-time
       example: "2018-09-17T12:46:47+01:00"
       description: "The date after which this bill is no longer valid or applicable"
+      nullable: true
     extension_date:
       type: string
       format: date-time
       example: "2018-09-17T12:46:47+01:00"
       description: "The date before which the bill must be renewed (or cancelled)"
+      nullable: true
     repeat_freq:
       $ref: '#/components/schemas/BillRepeatFrequency'
     skip:

--- a/yaml/v1/schemas/models/PiggyBankEvent.yaml
+++ b/yaml/v1/schemas/models/PiggyBankEvent.yaml
@@ -34,8 +34,10 @@ PiggyBankEvent:
       format: string
       example: "4291"
       description: The journal associated with the event.
+      nullable: true
     transaction_group_id:
       type: string
       format: string
       example: "4291"
       description: The transaction group associated with the event.
+      nullable: true

--- a/yaml/v1/schemas/models/TransactionSplit/TransactionSplitStore.yaml
+++ b/yaml/v1/schemas/models/TransactionSplit/TransactionSplitStore.yaml
@@ -118,11 +118,13 @@ TransactionSplitStore:
       format: int32
       description: Optional. Use either this or the piggy_bank_name
       writeOnly: true
+      nullable: true
     piggy_bank_name:
       type: string
       format: string
       description: Optional. Use either this or the piggy_bank_id
       writeOnly: true
+      nullable: true
     bill_id:
       type: string
       format: string


### PR DESCRIPTION
The Swagger Code Generator I use recently added "proper" support for nullable/optional fields. As it's a strongly typed language, anything that doesn't match the swagger yaml file throws an error.

This PR fixes a couple of the errors I encountered, mostly nullable fields not being marked as nullable.

Thank you!