### PR TITLE
Improve transaction yaml descriptions

### DIFF
--- a/yaml/v1/paths/models/transaction.yaml
+++ b/yaml/v1/paths/models/transaction.yaml
@@ -1,8 +1,8 @@
 /transactions:
   get:
     summary: |
-      List all the user's transactions.
-    description: List all the user's transactions.
+      List all the user's transactions groups.
+    description: List all the user's transactions groups.
     operationId: listTransaction
     tags:
       - transactions
@@ -46,8 +46,8 @@
       !badRequestResponse,3
       !internalExceptionResponse,3
   post:
-    summary: Store a new transaction
-    description: Creates a new transaction. The data required can be submitted as a JSON body or as a list of parameters.
+    summary: Store a new transaction group
+    description: Creates a new transaction group. The data required can be submitted as a JSON body or as a list of parameters.
     operationId: storeTransaction
     parameters:
       !correlationParameter,3
@@ -107,7 +107,7 @@
     tags:
       - transactions
     description: Update an existing transaction group.
-    summary: Update existing transaction. For more information, see https://docs.firefly-iii.org/firefly-iii/api/specials
+    summary: Update existing transaction group. For more information, see https://docs.firefly-iii.org/firefly-iii/api/specials
     parameters:
         !correlationParameter,3
       - in: path

--- a/yaml/v1/paths/models/transaction.yaml
+++ b/yaml/v1/paths/models/transaction.yaml
@@ -77,8 +77,8 @@
       !internalExceptionResponse,3
 /transactions/{id}:
   get:
-    summary: Get a single transaction.
-    description: Get a single transaction.
+    summary: Get a single transaction group.
+    description: Get a single transaction group.
     operationId: getTransaction
     parameters:
         !correlationParameter,3
@@ -88,7 +88,7 @@
         schema:
           type: string
           example: "123"
-        description: The ID of the transaction.
+        description: The ID of the transaction group.
     tags:
       - transactions
     responses:
@@ -106,7 +106,7 @@
     operationId: updateTransaction
     tags:
       - transactions
-    description: Update an existing transaction.
+    description: Update an existing transaction group.
     summary: Update existing transaction. For more information, see https://docs.firefly-iii.org/firefly-iii/api/specials
     parameters:
         !correlationParameter,3
@@ -116,7 +116,7 @@
         schema:
           type: string
           example: "123"
-        description: The ID of the transaction.
+        description: The ID of the transaction group.
     requestBody:
       content:
         application/json:
@@ -141,8 +141,8 @@
       !internalExceptionResponse,3
   delete:
     operationId: deleteTransaction
-    description: Delete a transaction.
-    summary: Delete a transaction.
+    description: Delete a transaction group.
+    summary: Delete a transaction group.
     tags:
       - transactions
     parameters:
@@ -153,7 +153,7 @@
         schema:
           type: string
           example: "123"
-        description: The ID of the transaction.
+        description: The ID of the transaction group.
     responses:
       204:
         description: Transaction deleted.


### PR DESCRIPTION
I've been struggling for a few days, because while reading the description for update, I used "transaction id" from "transaction table", however it was supposed to be "transaction group id" from "transaction group table".

This PR improves the description for better understading.