### PR TITLE
fix(BasicSummary): correctly type dictionary using `additionalProperties`

### DIFF
--- a/yaml/v1/schemas/summary/BasicSummary.yaml
+++ b/yaml/v1/schemas/summary/BasicSummary.yaml
@@ -1,4 +1,4 @@
 BasicSummary:
   type: object
-  items:
+  additionalProperties:
     $ref: '#/components/schemas/BasicSummaryEntry'


### PR DESCRIPTION
The `BasicSummary` schema is currently incorrectly typed, making the result type being effectively any object. By changing the `items` property to `additionalProperties`, the `BasicSummary` type can be properly specified as a dictionary, as documented [here](https://swagger.io/docs/specification/data-models/dictionaries/).