### PR TITLE
fix(WebhookMessage): rename webhook message field to reflect api behavior

### DIFF
--- a/yaml/v1/schemas/models/WebhookMessage.yaml
+++ b/yaml/v1/schemas/models/WebhookMessage.yaml
@@ -31,7 +31,7 @@ WebhookMessage:
       format: string
       example: "7a344c02-5b52-46b1-90e6-a437431dcf07"
       description: "Long UUID string for identification of this webhook message."
-    string:
+    message:
       type: string
       format: string
       example: "{some:message}"


### PR DESCRIPTION
The string on the `WebhookMessage` schema that contains the actual message that was sent is named `string` in the API doc currently, but based on the API behavior, should be `message` instead. 