### PR TITLE
Add missing pagination parameters to `/bills/{id}/transactions`

### DIFF
--- a/yaml/v1/paths/models/bill-list.yaml
+++ b/yaml/v1/paths/models/bill-list.yaml
@@ -63,6 +63,8 @@
       - bills
     parameters:
         !correlationParameter,3
+        !limitParameter,3
+        !pageParameter,3
       - in: path
         name: id
         required: true


### PR DESCRIPTION
Changes in this pull request:

- `/bills/{id}/transactions` was missing the `limit` & `page` parameter. The API actually supports both, just a documentation issue
-
-

Originally discovered by @dballagi

@JC5
